### PR TITLE
Add Feedback Collection After Chat Sessions

### DIFF
--- a/app/schemas.py
+++ b/app/schemas.py
@@ -104,6 +104,7 @@ class ChatSession(ChatSessionBase):
     ended_at: Optional[datetime] = None
     user: User
     escalation: Optional[Escalation] = None
+    feedback: Optional["ChatFeedback"] = None
 
     class Config:
         from_attributes = True
@@ -127,6 +128,54 @@ class ChatMessage(ChatMessageBase):
 
     class Config:
         from_attributes = True
+
+# Feedback Schemas
+class FeedbackBase(BaseModel):
+    rating: Optional[int] = Field(None, ge=1, le=5, description="1-5 star rating")
+    thumbs_rating: Optional[bool] = Field(None, description="True for thumbs up, False for thumbs down")
+    feedback_text: Optional[str] = Field(None, max_length=1000, description="Optional text feedback")
+    feedback_tags: Optional[List[str]] = Field(None, description="Predefined feedback tags")
+    resolution_helpful: Optional[bool] = Field(None, description="Was the resolution helpful?")
+    response_time_rating: Optional[int] = Field(None, ge=1, le=5, description="Response time rating")
+
+class FeedbackCreate(FeedbackBase):
+    pass
+
+class FeedbackUpdate(BaseModel):
+    rating: Optional[int] = Field(None, ge=1, le=5)
+    thumbs_rating: Optional[bool] = None
+    feedback_text: Optional[str] = Field(None, max_length=1000)
+    feedback_tags: Optional[List[str]] = None
+    resolution_helpful: Optional[bool] = None
+    response_time_rating: Optional[int] = Field(None, ge=1, le=5)
+
+class ChatFeedback(FeedbackBase):
+    id: int
+    session_id: int
+    user_id: int
+    agent_id: Optional[int] = None
+    created_at: datetime
+    user: User
+    agent: Optional[User] = None
+
+    class Config:
+        from_attributes = True
+
+# Feedback Analytics Schemas
+class FeedbackStats(BaseModel):
+    total_feedback: int
+    average_rating: Optional[float] = None
+    thumbs_up_percentage: Optional[float] = None
+    resolution_helpful_percentage: Optional[float] = None
+    average_response_time_rating: Optional[float] = None
+    common_tags: List[Dict[str, Any]] = []
+
+class FeedbackSummary(BaseModel):
+    session_id: str
+    rating: Optional[int] = None
+    thumbs_rating: Optional[bool] = None
+    feedback_text: Optional[str] = None
+    created_at: datetime
 
 # WebSocket Schemas
 class WebSocketMessage(BaseModel):
@@ -183,6 +232,11 @@ class DashboardStats(BaseModel):
     active_chat_sessions: int
     online_agents: int
     average_resolution_time: Optional[float] = None
+    # New feedback metrics
+    total_feedback_received: int = 0
+    average_feedback_rating: Optional[float] = None
+    customer_satisfaction_percentage: Optional[float] = None
+    feedback_response_rate: Optional[float] = None
 
 class EscalationsByPriority(BaseModel):
     low: int

--- a/app/services/feedback_service.py
+++ b/app/services/feedback_service.py
@@ -1,0 +1,318 @@
+import json
+from typing import List, Optional, Dict, Any
+from sqlalchemy.orm import Session
+from sqlalchemy import func, desc, and_
+from datetime import datetime, timedelta
+
+from ..models import ChatFeedback, ChatSession, User
+from ..schemas import FeedbackCreate, FeedbackUpdate, FeedbackStats
+from ..websocket_manager import manager
+
+class FeedbackService:
+    def __init__(self, db: Session):
+        self.db = db
+
+    def create_feedback(
+        self, 
+        session_id: int, 
+        user_id: int, 
+        feedback_data: FeedbackCreate
+    ) -> Optional[ChatFeedback]:
+        """Create feedback for a chat session"""
+        
+        # Check if session exists
+        session = self.db.query(ChatSession).filter(ChatSession.id == session_id).first()
+        if not session:
+            return None
+        
+        # Check if feedback already exists for this session
+        existing_feedback = self.db.query(ChatFeedback).filter(
+            ChatFeedback.session_id == session_id,
+            ChatFeedback.user_id == user_id
+        ).first()
+        
+        if existing_feedback:
+            return None  # Feedback already exists
+        
+        # Find the agent who handled the session (last agent to send a message)
+        agent_id = None
+        if session.messages:
+            # Get the last agent message
+            agent_message = self.db.query(ChatSession).join(ChatSession.messages).join(
+                User, User.id == ChatSession.user_id
+            ).filter(
+                ChatSession.id == session_id,
+                User.role.in_(["agent", "admin"])
+            ).first()
+            
+            if agent_message:
+                agent_id = agent_message.user_id
+        
+        # Create feedback
+        db_feedback = ChatFeedback(
+            session_id=session_id,
+            user_id=user_id,
+            agent_id=agent_id,
+            rating=feedback_data.rating,
+            thumbs_rating=feedback_data.thumbs_rating,
+            feedback_text=feedback_data.feedback_text,
+            feedback_tags=json.dumps(feedback_data.feedback_tags) if feedback_data.feedback_tags else None,
+            resolution_helpful=feedback_data.resolution_helpful,
+            response_time_rating=feedback_data.response_time_rating
+        )
+        
+        self.db.add(db_feedback)
+        self.db.commit()
+        self.db.refresh(db_feedback)
+        
+        return db_feedback
+
+    def update_feedback(
+        self, 
+        feedback_id: int, 
+        user_id: int, 
+        feedback_data: FeedbackUpdate
+    ) -> Optional[ChatFeedback]:
+        """Update existing feedback"""
+        
+        feedback = self.db.query(ChatFeedback).filter(
+            ChatFeedback.id == feedback_id,
+            ChatFeedback.user_id == user_id
+        ).first()
+        
+        if not feedback:
+            return None
+        
+        # Update fields
+        if feedback_data.rating is not None:
+            feedback.rating = feedback_data.rating
+        if feedback_data.thumbs_rating is not None:
+            feedback.thumbs_rating = feedback_data.thumbs_rating
+        if feedback_data.feedback_text is not None:
+            feedback.feedback_text = feedback_data.feedback_text
+        if feedback_data.feedback_tags is not None:
+            feedback.feedback_tags = json.dumps(feedback_data.feedback_tags)
+        if feedback_data.resolution_helpful is not None:
+            feedback.resolution_helpful = feedback_data.resolution_helpful
+        if feedback_data.response_time_rating is not None:
+            feedback.response_time_rating = feedback_data.response_time_rating
+        
+        self.db.commit()
+        self.db.refresh(feedback)
+        
+        return feedback
+
+    def get_session_feedback(self, session_id: int) -> Optional[ChatFeedback]:
+        """Get feedback for a specific session"""
+        return self.db.query(ChatFeedback).filter(
+            ChatFeedback.session_id == session_id
+        ).first()
+
+    def get_user_feedback_history(self, user_id: int, limit: int = 50) -> List[ChatFeedback]:
+        """Get feedback history for a user"""
+        return self.db.query(ChatFeedback).filter(
+            ChatFeedback.user_id == user_id
+        ).order_by(desc(ChatFeedback.created_at)).limit(limit).all()
+
+    def get_agent_feedback(self, agent_id: int, limit: int = 50) -> List[ChatFeedback]:
+        """Get feedback for a specific agent"""
+        return self.db.query(ChatFeedback).filter(
+            ChatFeedback.agent_id == agent_id
+        ).order_by(desc(ChatFeedback.created_at)).limit(limit).all()
+
+    def get_feedback_stats(self, days: int = 30) -> FeedbackStats:
+        """Get feedback statistics for the last N days"""
+        
+        start_date = datetime.utcnow() - timedelta(days=days)
+        
+        # Base query for the time period
+        base_query = self.db.query(ChatFeedback).filter(
+            ChatFeedback.created_at >= start_date
+        )
+        
+        # Total feedback count
+        total_feedback = base_query.count()
+        
+        if total_feedback == 0:
+            return FeedbackStats(
+                total_feedback=0,
+                average_rating=None,
+                thumbs_up_percentage=None,
+                resolution_helpful_percentage=None,
+                average_response_time_rating=None,
+                common_tags=[]
+            )
+        
+        # Average rating (1-5 scale)
+        avg_rating_result = base_query.filter(
+            ChatFeedback.rating.isnot(None)
+        ).with_entities(func.avg(ChatFeedback.rating)).scalar()
+        
+        # Thumbs up percentage
+        thumbs_up_count = base_query.filter(
+            ChatFeedback.thumbs_rating == True
+        ).count()
+        thumbs_total = base_query.filter(
+            ChatFeedback.thumbs_rating.isnot(None)
+        ).count()
+        thumbs_up_percentage = (thumbs_up_count / thumbs_total * 100) if thumbs_total > 0 else None
+        
+        # Resolution helpful percentage
+        helpful_count = base_query.filter(
+            ChatFeedback.resolution_helpful == True
+        ).count()
+        helpful_total = base_query.filter(
+            ChatFeedback.resolution_helpful.isnot(None)
+        ).count()
+        helpful_percentage = (helpful_count / helpful_total * 100) if helpful_total > 0 else None
+        
+        # Average response time rating
+        avg_response_time = base_query.filter(
+            ChatFeedback.response_time_rating.isnot(None)
+        ).with_entities(func.avg(ChatFeedback.response_time_rating)).scalar()
+        
+        # Common tags
+        common_tags = self._get_common_tags(base_query)
+        
+        return FeedbackStats(
+            total_feedback=total_feedback,
+            average_rating=round(avg_rating_result, 2) if avg_rating_result else None,
+            thumbs_up_percentage=round(thumbs_up_percentage, 2) if thumbs_up_percentage else None,
+            resolution_helpful_percentage=round(helpful_percentage, 2) if helpful_percentage else None,
+            average_response_time_rating=round(avg_response_time, 2) if avg_response_time else None,
+            common_tags=common_tags
+        )
+
+    def _get_common_tags(self, base_query) -> List[Dict[str, Any]]:
+        """Get most common feedback tags"""
+        
+        feedback_with_tags = base_query.filter(
+            ChatFeedback.feedback_tags.isnot(None)
+        ).all()
+        
+        tag_counts = {}
+        
+        for feedback in feedback_with_tags:
+            if feedback.feedback_tags:
+                try:
+                    tags = json.loads(feedback.feedback_tags)
+                    for tag in tags:
+                        tag_counts[tag] = tag_counts.get(tag, 0) + 1
+                except json.JSONDecodeError:
+                    continue
+        
+        # Sort by count and return top 10
+        sorted_tags = sorted(tag_counts.items(), key=lambda x: x[1], reverse=True)[:10]
+        
+        return [
+            {"tag": tag, "count": count, "percentage": round(count / len(feedback_with_tags) * 100, 2)}
+            for tag, count in sorted_tags
+        ]
+
+    def get_agent_performance(self, agent_id: int, days: int = 30) -> Dict[str, Any]:
+        """Get performance metrics for a specific agent"""
+        
+        start_date = datetime.utcnow() - timedelta(days=days)
+        
+        agent_feedback = self.db.query(ChatFeedback).filter(
+            ChatFeedback.agent_id == agent_id,
+            ChatFeedback.created_at >= start_date
+        )
+        
+        total_feedback = agent_feedback.count()
+        
+        if total_feedback == 0:
+            return {
+                "agent_id": agent_id,
+                "total_feedback": 0,
+                "average_rating": None,
+                "thumbs_up_percentage": None,
+                "resolution_helpful_percentage": None,
+                "average_response_time_rating": None
+            }
+        
+        # Calculate metrics
+        avg_rating = agent_feedback.filter(
+            ChatFeedback.rating.isnot(None)
+        ).with_entities(func.avg(ChatFeedback.rating)).scalar()
+        
+        thumbs_up_count = agent_feedback.filter(
+            ChatFeedback.thumbs_rating == True
+        ).count()
+        thumbs_total = agent_feedback.filter(
+            ChatFeedback.thumbs_rating.isnot(None)
+        ).count()
+        thumbs_up_percentage = (thumbs_up_count / thumbs_total * 100) if thumbs_total > 0 else None
+        
+        helpful_count = agent_feedback.filter(
+            ChatFeedback.resolution_helpful == True
+        ).count()
+        helpful_total = agent_feedback.filter(
+            ChatFeedback.resolution_helpful.isnot(None)
+        ).count()
+        helpful_percentage = (helpful_count / helpful_total * 100) if helpful_total > 0 else None
+        
+        avg_response_time = agent_feedback.filter(
+            ChatFeedback.response_time_rating.isnot(None)
+        ).with_entities(func.avg(ChatFeedback.response_time_rating)).scalar()
+        
+        return {
+            "agent_id": agent_id,
+            "total_feedback": total_feedback,
+            "average_rating": round(avg_rating, 2) if avg_rating else None,
+            "thumbs_up_percentage": round(thumbs_up_percentage, 2) if thumbs_up_percentage else None,
+            "resolution_helpful_percentage": round(helpful_percentage, 2) if helpful_percentage else None,
+            "average_response_time_rating": round(avg_response_time, 2) if avg_response_time else None
+        }
+
+    async def request_feedback(self, session_id: str):
+        """Send feedback request to session participants"""
+        
+        # Get session from database
+        session = self.db.query(ChatSession).filter(
+            ChatSession.session_id == session_id
+        ).first()
+        
+        if not session:
+            return False
+        
+        # Check if feedback already exists
+        existing_feedback = self.db.query(ChatFeedback).filter(
+            ChatFeedback.session_id == session.id
+        ).first()
+        
+        if existing_feedback:
+            return False  # Feedback already collected
+        
+        # Send feedback request via WebSocket
+        feedback_request = {
+            "type": "feedback_request",
+            "data": {
+                "session_id": session_id,
+                "message": "How was your chat experience? Please rate your session.",
+                "feedback_options": {
+                    "rating_scale": {"min": 1, "max": 5, "label": "Overall Experience"},
+                    "thumbs_rating": {"label": "Was this helpful?"},
+                    "resolution_helpful": {"label": "Did we resolve your issue?"},
+                    "response_time_rating": {"min": 1, "max": 5, "label": "Response Time"},
+                    "predefined_tags": [
+                        "Quick Response", "Helpful Agent", "Clear Communication",
+                        "Problem Solved", "Professional Service", "Friendly Support",
+                        "Technical Expertise", "Patient Assistance"
+                    ]
+                }
+            }
+        }
+        
+        await manager.broadcast_to_session(session_id, feedback_request)
+        return True
+
+    def get_predefined_tags(self) -> List[str]:
+        """Get list of predefined feedback tags"""
+        return [
+            "Quick Response", "Helpful Agent", "Clear Communication",
+            "Problem Solved", "Professional Service", "Friendly Support",
+            "Technical Expertise", "Patient Assistance", "Knowledgeable",
+            "Courteous", "Efficient", "Understanding", "Thorough",
+            "Responsive", "Accurate Information", "Good Follow-up"
+        ]

--- a/scripts/add_feedback.py
+++ b/scripts/add_feedback.py
@@ -1,0 +1,61 @@
+"""
+Database migration script to add feedback tables
+Run this script to add the feedback functionality to existing databases
+"""
+
+from sqlalchemy import create_engine, text
+from app.config import settings
+
+def run_migration():
+    """Run the feedback tables migration"""
+    
+    engine = create_engine(settings.DATABASE_URL)
+    
+    # SQL to create the chat_feedback table
+    create_feedback_table_sql = """
+    CREATE TABLE IF NOT EXISTS chat_feedback (
+        id SERIAL PRIMARY KEY,
+        session_id INTEGER NOT NULL REFERENCES chat_sessions(id) ON DELETE CASCADE,
+        user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+        rating INTEGER CHECK (rating >= 1 AND rating <= 5),
+        thumbs_rating BOOLEAN,
+        feedback_text TEXT,
+        feedback_tags TEXT,
+        agent_id INTEGER REFERENCES users(id) ON DELETE SET NULL,
+        resolution_helpful BOOLEAN,
+        response_time_rating INTEGER CHECK (response_time_rating >= 1 AND response_time_rating <= 5),
+        created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+    );
+    """
+    
+    # Create indexes for better performance
+    create_indexes_sql = """
+    CREATE INDEX IF NOT EXISTS idx_chat_feedback_session_id ON chat_feedback(session_id);
+    CREATE INDEX IF NOT EXISTS idx_chat_feedback_user_id ON chat_feedback(user_id);
+    CREATE INDEX IF NOT EXISTS idx_chat_feedback_agent_id ON chat_feedback(agent_id);
+    CREATE INDEX IF NOT EXISTS idx_chat_feedback_created_at ON chat_feedback(created_at);
+    CREATE INDEX IF NOT EXISTS idx_chat_feedback_rating ON chat_feedback(rating);
+    """
+    
+    try:
+        with engine.connect() as connection:
+            # Create the table
+            connection.execute(text(create_feedback_table_sql))
+            print("✅ Created chat_feedback table")
+            
+            # Create indexes
+            connection.execute(text(create_indexes_sql))
+            print("✅ Created indexes for chat_feedback table")
+            
+            # Commit the transaction
+            connection.commit()
+            print("✅ Migration completed successfully")
+            
+    except Exception as e:
+        print(f"❌ Migration failed: {e}")
+        raise
+
+if __name__ == "__main__":
+    print("🚀 Running feedback tables migration...")
+    run_migration()
+    print("🎉 Migration completed!")

--- a/scripts/test_feedback.py
+++ b/scripts/test_feedback.py
@@ -1,0 +1,242 @@
+"""
+Test script for the feedback collection system
+"""
+
+import asyncio
+import requests
+import json
+from datetime import datetime
+
+# Configuration
+API_BASE_URL = "http://localhost:8000"
+
+def test_feedback_api():
+    """Test feedback API endpoints"""
+    print("🧪 Testing Feedback API...")
+    
+    # Authenticate
+    auth_response = requests.post(f"{API_BASE_URL}/auth/login", json={
+        "username": "admin",
+        "password": "admin123"
+    })
+    
+    if auth_response.status_code != 200:
+        print("❌ Authentication failed")
+        return
+    
+    token = auth_response.json()["access_token"]
+    headers = {"Authorization": f"Bearer {token}"}
+    
+    print("✅ Authentication successful")
+    
+    # Create a chat session
+    session_response = requests.post(
+        f"{API_BASE_URL}/chat/sessions",
+        json={"escalation_id": None},
+        headers=headers
+    )
+    
+    if session_response.status_code != 200:
+        print("❌ Failed to create chat session")
+        return
+    
+    session_id = session_response.json()["session_id"]
+    print(f"✅ Chat session created: {session_id}")
+    
+    # Send a message to simulate chat activity
+    message_response = requests.post(
+        f"{API_BASE_URL}/chat/sessions/{session_id}/messages",
+        json={
+            "content": "Hello, I need help with my account",
+            "message_type": "text"
+        },
+        headers=headers
+    )
+    
+    if message_response.status_code == 200:
+        print("✅ Test message sent")
+    
+    # Test feedback creation
+    feedback_data = {
+        "rating": 5,
+        "thumbs_rating": True,
+        "feedback_text": "Great service! Very helpful agent.",
+        "feedback_tags": ["Quick Response", "Helpful Agent", "Problem Solved"],
+        "resolution_helpful": True,
+        "response_time_rating": 4
+    }
+    
+    feedback_response = requests.post(
+        f"{API_BASE_URL}/chat/sessions/{session_id}/feedback",
+        json=feedback_data,
+        headers=headers
+    )
+    
+    if feedback_response.status_code == 200:
+        feedback = feedback_response.json()
+        print(f"✅ Feedback created: ID {feedback['id']}")
+        print(f"   Rating: {feedback['rating']}/5")
+        print(f"   Thumbs: {'👍' if feedback['thumbs_rating'] else '👎'}")
+        print(f"   Text: {feedback['feedback_text']}")
+    else:
+        print(f"❌ Failed to create feedback: {feedback_response.text}")
+        return
+    
+    # Test getting feedback
+    get_feedback_response = requests.get(
+        f"{API_BASE_URL}/chat/sessions/{session_id}/feedback",
+        headers=headers
+    )
+    
+    if get_feedback_response.status_code == 200:
+        print("✅ Retrieved session feedback")
+    
+    # Test feedback update
+    update_data = {
+        "rating": 4,
+        "feedback_text": "Updated: Good service, could be faster."
+    }
+    
+    update_response = requests.put(
+        f"{API_BASE_URL}/chat/feedback/{feedback['id']}",
+        json=update_data,
+        headers=headers
+    )
+    
+    if update_response.status_code == 200:
+        print("✅ Feedback updated successfully")
+    
+    # Test getting predefined tags
+    tags_response = requests.get(
+        f"{API_BASE_URL}/chat/feedback/tags",
+        headers=headers
+    )
+    
+    if tags_response.status_code == 200:
+        tags = tags_response.json()
+        print(f"✅ Retrieved {len(tags)} predefined tags")
+    
+    # Test feedback statistics (admin only)
+    stats_response = requests.get(
+        f"{API_BASE_URL}/chat/feedback/stats?days=30",
+        headers=headers
+    )
+    
+    if stats_response.status_code == 200:
+        stats = stats_response.json()
+        print("✅ Feedback statistics:")
+        print(f"   Total feedback: {stats['total_feedback']}")
+        print(f"   Average rating: {stats['average_rating']}")
+        print(f"   Thumbs up %: {stats['thumbs_up_percentage']}")
+    
+    # Test feedback history
+    history_response = requests.get(
+        f"{API_BASE_URL}/chat/feedback/my-history",
+        headers=headers
+    )
+    
+    if history_response.status_code == 200:
+        history = history_response.json()
+        print(f"✅ Retrieved {len(history)} feedback entries from history")
+    
+    # Test requesting feedback
+    request_response = requests.post(
+        f"{API_BASE_URL}/chat/sessions/{session_id}/request-feedback",
+        headers=headers
+    )
+    
+    if request_response.status_code == 200:
+        print("✅ Feedback request sent successfully")
+    
+    print("\n🎉 All feedback API tests completed!")
+
+def test_feedback_scenarios():
+    """Test different feedback scenarios"""
+    print("\n🎭 Testing Feedback Scenarios...")
+    
+    scenarios = [
+        {
+            "name": "Excellent Experience",
+            "data": {
+                "rating": 5,
+                "thumbs_rating": True,
+                "feedback_text": "Outstanding support! Resolved my issue quickly.",
+                "feedback_tags": ["Quick Response", "Problem Solved", "Professional Service"],
+                "resolution_helpful": True,
+                "response_time_rating": 5
+            }
+        },
+        {
+            "name": "Good Experience",
+            "data": {
+                "rating": 4,
+                "thumbs_rating": True,
+                "feedback_text": "Good help, took a bit longer than expected.",
+                "feedback_tags": ["Helpful Agent", "Clear Communication"],
+                "resolution_helpful": True,
+                "response_time_rating": 3
+            }
+        },
+        {
+            "name": "Poor Experience",
+            "data": {
+                "rating": 2,
+                "thumbs_rating": False,
+                "feedback_text": "Agent was not very helpful, issue not resolved.",
+                "feedback_tags": [],
+                "resolution_helpful": False,
+                "response_time_rating": 2
+            }
+        },
+        {
+            "name": "Minimal Feedback",
+            "data": {
+                "thumbs_rating": True
+            }
+        }
+    ]
+    
+    # Authenticate
+    auth_response = requests.post(f"{API_BASE_URL}/auth/login", json={
+        "username": "admin",
+        "password": "admin123"
+    })
+    
+    token = auth_response.json()["access_token"]
+    headers = {"Authorization": f"Bearer {token}"}
+    
+    for scenario in scenarios:
+        print(f"\n📝 Testing: {scenario['name']}")
+        
+        # Create session for each scenario
+        session_response = requests.post(
+            f"{API_BASE_URL}/chat/sessions",
+            json={"escalation_id": None},
+            headers=headers
+        )
+        
+        session_id = session_response.json()["session_id"]
+        
+        # Submit feedback
+        feedback_response = requests.post(
+            f"{API_BASE_URL}/chat/sessions/{session_id}/feedback",
+            json=scenario["data"],
+            headers=headers
+        )
+        
+        if feedback_response.status_code == 200:
+            print(f"   ✅ {scenario['name']} feedback submitted")
+        else:
+            print(f"   ❌ Failed to submit {scenario['name']} feedback")
+
+if __name__ == "__main__":
+    print("🚀 Starting Feedback System Tests")
+    print("=" * 50)
+    
+    # Test basic API functionality
+    test_feedback_api()
+    
+    # Test different feedback scenarios
+    test_feedback_scenarios()
+    
+    print("\n✅ All tests completed!")

--- a/static/feedback_test.html
+++ b/static/feedback_test.html
@@ -1,0 +1,601 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Feedback Collection Test</title>
+    <style>
+      body {
+        font-family: Arial, sans-serif;
+        max-width: 800px;
+        margin: 0 auto;
+        padding: 20px;
+        background-color: #f5f5f5;
+      }
+      .container {
+        background: white;
+        padding: 20px;
+        border-radius: 8px;
+        box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
+        margin-bottom: 20px;
+      }
+      .feedback-form {
+        border: 1px solid #ddd;
+        padding: 20px;
+        border-radius: 8px;
+        background: #f9f9f9;
+      }
+      .rating-stars {
+        display: flex;
+        gap: 5px;
+        margin: 10px 0;
+      }
+      .star {
+        font-size: 24px;
+        color: #ddd;
+        cursor: pointer;
+        transition: color 0.2s;
+      }
+      .star.active,
+      .star:hover {
+        color: #ffd700;
+      }
+      .thumbs {
+        display: flex;
+        gap: 10px;
+        margin: 10px 0;
+      }
+      .thumb {
+        font-size: 24px;
+        cursor: pointer;
+        padding: 10px;
+        border: 2px solid #ddd;
+        border-radius: 50%;
+        transition: all 0.2s;
+      }
+      .thumb.active {
+        border-color: #007bff;
+        background: #007bff;
+        color: white;
+      }
+      .tags {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 8px;
+        margin: 10px 0;
+      }
+      .tag {
+        padding: 5px 10px;
+        border: 1px solid #ddd;
+        border-radius: 15px;
+        cursor: pointer;
+        font-size: 12px;
+        transition: all 0.2s;
+      }
+      .tag.selected {
+        background: #007bff;
+        color: white;
+        border-color: #007bff;
+      }
+      textarea {
+        width: 100%;
+        min-height: 80px;
+        padding: 10px;
+        border: 1px solid #ddd;
+        border-radius: 4px;
+        resize: vertical;
+      }
+      button {
+        background: #007bff;
+        color: white;
+        border: none;
+        padding: 10px 20px;
+        border-radius: 4px;
+        cursor: pointer;
+        margin: 5px;
+      }
+      button:hover {
+        background: #0056b3;
+      }
+      button:disabled {
+        background: #ccc;
+        cursor: not-allowed;
+      }
+      .form-group {
+        margin-bottom: 15px;
+      }
+      label {
+        display: block;
+        margin-bottom: 5px;
+        font-weight: bold;
+      }
+      .stats {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+        gap: 15px;
+        margin-top: 20px;
+      }
+      .stat-card {
+        background: #f8f9fa;
+        padding: 15px;
+        border-radius: 6px;
+        text-align: center;
+      }
+      .stat-value {
+        font-size: 24px;
+        font-weight: bold;
+        color: #007bff;
+      }
+      .stat-label {
+        font-size: 12px;
+        color: #666;
+        margin-top: 5px;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>Feedback Collection System Test</h1>
+
+    <!-- Session Setup -->
+    <div class="container">
+      <h2>Session Setup</h2>
+      <div class="form-group">
+        <label>JWT Token:</label>
+        <input
+          type="text"
+          id="token"
+          placeholder="Enter JWT token"
+          style="width: 100%; padding: 8px"
+        />
+      </div>
+      <div class="form-group">
+        <label>Session ID:</label>
+        <input
+          type="text"
+          id="sessionId"
+          placeholder="Session ID"
+          style="width: 100%; padding: 8px"
+        />
+      </div>
+      <button onclick="createSession()">Create New Session</button>
+      <button onclick="loadFeedbackTags()">Load Predefined Tags</button>
+    </div>
+
+    <!-- Feedback Form -->
+    <div class="container">
+      <h2>Submit Feedback</h2>
+      <div class="feedback-form">
+        <div class="form-group">
+          <label>Overall Experience (1-5 stars):</label>
+          <div class="rating-stars" id="ratingStars">
+            <span class="star" data-rating="1">★</span>
+            <span class="star" data-rating="2">★</span>
+            <span class="star" data-rating="3">★</span>
+            <span class="star" data-rating="4">★</span>
+            <span class="star" data-rating="5">★</span>
+          </div>
+        </div>
+
+        <div class="form-group">
+          <label>Was this helpful?</label>
+          <div class="thumbs">
+            <span class="thumb" data-thumbs="true">👍</span>
+            <span class="thumb" data-thumbs="false">👎</span>
+          </div>
+        </div>
+
+        <div class="form-group">
+          <label>Response Time (1-5 stars):</label>
+          <div class="rating-stars" id="responseTimeStars">
+            <span class="star" data-rating="1">★</span>
+            <span class="star" data-rating="2">★</span>
+            <span class="star" data-rating="3">★</span>
+            <span class="star" data-rating="4">★</span>
+            <span class="star" data-rating="5">★</span>
+          </div>
+        </div>
+
+        <div class="form-group">
+          <label>Did we resolve your issue?</label>
+          <div class="thumbs">
+            <span class="thumb" data-resolution="true">✅ Yes</span>
+            <span class="thumb" data-resolution="false">❌ No</span>
+          </div>
+        </div>
+
+        <div class="form-group">
+          <label>Tags (select all that apply):</label>
+          <div class="tags" id="feedbackTags">
+            <!-- Tags will be loaded dynamically -->
+          </div>
+        </div>
+
+        <div class="form-group">
+          <label>Additional Comments:</label>
+          <textarea
+            id="feedbackText"
+            placeholder="Tell us more about your experience..."
+          ></textarea>
+        </div>
+
+        <button onclick="submitFeedback()">Submit Feedback</button>
+        <button onclick="requestFeedback()">
+          Request Feedback (WebSocket)
+        </button>
+      </div>
+    </div>
+
+    <!-- Feedback Statistics -->
+    <div class="container">
+      <h2>Feedback Statistics</h2>
+      <button onclick="loadStats()">Load Statistics</button>
+      <div class="stats" id="statsContainer">
+        <!-- Stats will be loaded here -->
+      </div>
+    </div>
+
+    <!-- Feedback History -->
+    <div class="container">
+      <h2>My Feedback History</h2>
+      <button onclick="loadHistory()">Load My History</button>
+      <div id="historyContainer">
+        <!-- History will be loaded here -->
+      </div>
+    </div>
+
+    <script>
+      let currentRating = 0;
+      let currentThumbsRating = null;
+      let currentResponseTimeRating = 0;
+      let currentResolutionHelpful = null;
+      let selectedTags = [];
+
+      // Initialize event listeners
+      document.addEventListener("DOMContentLoaded", function () {
+        // Rating stars
+        document.querySelectorAll("#ratingStars .star").forEach((star) => {
+          star.addEventListener("click", function () {
+            currentRating = parseInt(this.dataset.rating);
+            updateStars("ratingStars", currentRating);
+          });
+        });
+
+        // Response time stars
+        document
+          .querySelectorAll("#responseTimeStars .star")
+          .forEach((star) => {
+            star.addEventListener("click", function () {
+              currentResponseTimeRating = parseInt(this.dataset.rating);
+              updateStars("responseTimeStars", currentResponseTimeRating);
+            });
+          });
+
+        // Thumbs rating
+        document.querySelectorAll("[data-thumbs]").forEach((thumb) => {
+          thumb.addEventListener("click", function () {
+            currentThumbsRating = this.dataset.thumbs === "true";
+            updateThumbs("[data-thumbs]", currentThumbsRating);
+          });
+        });
+
+        // Resolution helpful
+        document.querySelectorAll("[data-resolution]").forEach((thumb) => {
+          thumb.addEventListener("click", function () {
+            currentResolutionHelpful = this.dataset.resolution === "true";
+            updateThumbs("[data-resolution]", currentResolutionHelpful);
+          });
+        });
+      });
+
+      function updateStars(containerId, rating) {
+        const container = document.getElementById(containerId);
+        const stars = container.querySelectorAll(".star");
+        stars.forEach((star, index) => {
+          if (index < rating) {
+            star.classList.add("active");
+          } else {
+            star.classList.remove("active");
+          }
+        });
+      }
+
+      function updateThumbs(selector, value) {
+        document.querySelectorAll(selector).forEach((thumb) => {
+          if (
+            (thumb.dataset.thumbs === "true" && value === true) ||
+            (thumb.dataset.thumbs === "false" && value === false) ||
+            (thumb.dataset.resolution === "true" && value === true) ||
+            (thumb.dataset.resolution === "false" && value === false)
+          ) {
+            thumb.classList.add("active");
+          } else {
+            thumb.classList.remove("active");
+          }
+        });
+      }
+
+      async function createSession() {
+        const token = document.getElementById("token").value;
+        if (!token) {
+          alert("Please enter JWT token");
+          return;
+        }
+
+        try {
+          const response = await fetch("/chat/sessions", {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+              Authorization: `Bearer ${token}`,
+            },
+            body: JSON.stringify({}),
+          });
+
+          if (response.ok) {
+            const session = await response.json();
+            document.getElementById("sessionId").value = session.session_id;
+            alert(`Session created: ${session.session_id}`);
+          } else {
+            alert("Failed to create session");
+          }
+        } catch (error) {
+          alert(`Error: ${error.message}`);
+        }
+      }
+
+      async function loadFeedbackTags() {
+        const token = document.getElementById("token").value;
+        if (!token) {
+          alert("Please enter JWT token");
+          return;
+        }
+
+        try {
+          const response = await fetch("/chat/feedback/tags", {
+            headers: {
+              Authorization: `Bearer ${token}`,
+            },
+          });
+
+          if (response.ok) {
+            const tags = await response.json();
+            const container = document.getElementById("feedbackTags");
+            container.innerHTML = "";
+
+            tags.forEach((tag) => {
+              const tagElement = document.createElement("span");
+              tagElement.className = "tag";
+              tagElement.textContent = tag;
+              tagElement.addEventListener("click", function () {
+                if (selectedTags.includes(tag)) {
+                  selectedTags = selectedTags.filter((t) => t !== tag);
+                  this.classList.remove("selected");
+                } else {
+                  selectedTags.push(tag);
+                  this.classList.add("selected");
+                }
+              });
+              container.appendChild(tagElement);
+            });
+          }
+        } catch (error) {
+          alert(`Error loading tags: ${error.message}`);
+        }
+      }
+
+      async function submitFeedback() {
+        const token = document.getElementById("token").value;
+        const sessionId = document.getElementById("sessionId").value;
+        const feedbackText = document.getElementById("feedbackText").value;
+
+        if (!token || !sessionId) {
+          alert("Please enter token and session ID");
+          return;
+        }
+
+        const feedbackData = {
+          rating: currentRating || null,
+          thumbs_rating: currentThumbsRating,
+          response_time_rating: currentResponseTimeRating || null,
+          resolution_helpful: currentResolutionHelpful,
+          feedback_text: feedbackText || null,
+          feedback_tags: selectedTags.length > 0 ? selectedTags : null,
+        };
+
+        try {
+          const response = await fetch(`/chat/sessions/${sessionId}/feedback`, {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+              Authorization: `Bearer ${token}`,
+            },
+            body: JSON.stringify(feedbackData),
+          });
+
+          if (response.ok) {
+            const feedback = await response.json();
+            alert(`Feedback submitted successfully! ID: ${feedback.id}`);
+            resetForm();
+          } else {
+            const error = await response.text();
+            alert(`Failed to submit feedback: ${error}`);
+          }
+        } catch (error) {
+          alert(`Error: ${error.message}`);
+        }
+      }
+
+      async function requestFeedback() {
+        const token = document.getElementById("token").value;
+        const sessionId = document.getElementById("sessionId").value;
+
+        if (!token || !sessionId) {
+          alert("Please enter token and session ID");
+          return;
+        }
+
+        try {
+          const response = await fetch(
+            `/chat/sessions/${sessionId}/request-feedback`,
+            {
+              method: "POST",
+              headers: {
+                Authorization: `Bearer ${token}`,
+              },
+            }
+          );
+
+          if (response.ok) {
+            alert("Feedback request sent via WebSocket!");
+          } else {
+            alert("Failed to request feedback");
+          }
+        } catch (error) {
+          alert(`Error: ${error.message}`);
+        }
+      }
+
+      async function loadStats() {
+        const token = document.getElementById("token").value;
+        if (!token) {
+          alert("Please enter JWT token");
+          return;
+        }
+
+        try {
+          const response = await fetch("/chat/feedback/stats?days=30", {
+            headers: {
+              Authorization: `Bearer ${token}`,
+            },
+          });
+
+          if (response.ok) {
+            const stats = await response.json();
+            displayStats(stats);
+          } else {
+            alert("Failed to load statistics");
+          }
+        } catch (error) {
+          alert(`Error: ${error.message}`);
+        }
+      }
+
+      function displayStats(stats) {
+        const container = document.getElementById("statsContainer");
+        container.innerHTML = `
+                <div class="stat-card">
+                    <div class="stat-value">${stats.total_feedback}</div>
+                    <div class="stat-label">Total Feedback</div>
+                </div>
+                <div class="stat-card">
+                    <div class="stat-value">${
+                      stats.average_rating || "N/A"
+                    }</div>
+                    <div class="stat-label">Average Rating</div>
+                </div>
+                <div class="stat-card">
+                    <div class="stat-value">${
+                      stats.thumbs_up_percentage || "N/A"
+                    }%</div>
+                    <div class="stat-label">Thumbs Up</div>
+                </div>
+                <div class="stat-card">
+                    <div class="stat-value">${
+                      stats.resolution_helpful_percentage || "N/A"
+                    }%</div>
+                    <div class="stat-label">Resolution Helpful</div>
+                </div>
+            `;
+      }
+
+      async function loadHistory() {
+        const token = document.getElementById("token").value;
+        if (!token) {
+          alert("Please enter JWT token");
+          return;
+        }
+
+        try {
+          const response = await fetch("/chat/feedback/my-history", {
+            headers: {
+              Authorization: `Bearer ${token}`,
+            },
+          });
+
+          if (response.ok) {
+            const history = await response.json();
+            displayHistory(history);
+          } else {
+            alert("Failed to load history");
+          }
+        } catch (error) {
+          alert(`Error: ${error.message}`);
+        }
+      }
+
+      function displayHistory(history) {
+        const container = document.getElementById("historyContainer");
+        if (history.length === 0) {
+          container.innerHTML = "<p>No feedback history found.</p>";
+          return;
+        }
+
+        container.innerHTML = history
+          .map(
+            (feedback) => `
+                <div style="border: 1px solid #ddd; padding: 15px; margin: 10px 0; border-radius: 6px;">
+                    <div><strong>Rating:</strong> ${
+                      feedback.rating ? feedback.rating + "/5 ⭐" : "N/A"
+                    }</div>
+                    <div><strong>Thumbs:</strong> ${
+                      feedback.thumbs_rating !== null
+                        ? feedback.thumbs_rating
+                          ? "👍"
+                          : "👎"
+                        : "N/A"
+                    }</div>
+                    <div><strong>Resolution Helpful:</strong> ${
+                      feedback.resolution_helpful !== null
+                        ? feedback.resolution_helpful
+                          ? "Yes"
+                          : "No"
+                        : "N/A"
+                    }</div>
+                    <div><strong>Response Time:</strong> ${
+                      feedback.response_time_rating
+                        ? feedback.response_time_rating + "/5"
+                        : "N/A"
+                    }</div>
+                    <div><strong>Comments:</strong> ${
+                      feedback.feedback_text || "None"
+                    }</div>
+                    <div><strong>Date:</strong> ${new Date(
+                      feedback.created_at
+                    ).toLocaleString()}</div>
+                </div>
+            `
+          )
+          .join("");
+      }
+
+      function resetForm() {
+        currentRating = 0;
+        currentThumbsRating = null;
+        currentResponseTimeRating = 0;
+        currentResolutionHelpful = null;
+        selectedTags = [];
+
+        document.getElementById("feedbackText").value = "";
+        document
+          .querySelectorAll(".star")
+          .forEach((star) => star.classList.remove("active"));
+        document
+          .querySelectorAll(".thumb")
+          .forEach((thumb) => thumb.classList.remove("active"));
+        document
+          .querySelectorAll(".tag")
+          .forEach((tag) => tag.classList.remove("selected"));
+      }
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
This update introduces a feedback mechanism at the end of each chat session, allowing users to rate the experience using a **1–5 star scale** or **thumbs up/down** option. Feedback is stored per session for future analysis and service improvement.

### ✅ Key Changes:

* Prompt users for feedback after chat ends
* Support for both star rating and thumbs up/down
* Store feedback linked to individual chat sessions

### 🎯 Purpose:

To collect user feedback for evaluating and improving chat experience quality.

closes #1
