### PR TITLE
implemented analytics session variable

### DIFF
--- a/src/analytics/service.py
+++ b/src/analytics/service.py
@@ -40,6 +40,7 @@ class AnalyticsService:
         additional_metadata: Optional[Dict[str, Any]] = None
     ):
         """Log a ticket scan event."""
+        session = None
         try:
             session = get_session()
             scan_record = TicketScan(
@@ -71,10 +72,12 @@ class AnalyticsService:
                 "event_id": event_id,
                 "error": str(e)
             })
-            session.rollback()
+            if session:
+                session.rollback()
             raise
         finally:
-            session.close()
+            if session:
+                session.close()
     
     def log_ticket_transfer(
         self,
@@ -89,6 +92,7 @@ class AnalyticsService:
         additional_metadata: Optional[Dict[str, Any]] = None
     ):
         """Log a ticket transfer event."""
+        session = None
         try:
             session = get_session()
             transfer_record = TicketTransfer(
@@ -125,10 +129,12 @@ class AnalyticsService:
                 "to_user_id": to_user_id,
                 "error": str(e)
             })
-            session.rollback()
+            if session:
+                session.rollback()
             raise
         finally:
-            session.close()
+            if session:
+                session.close()
     
     def log_invalid_attempt(
         self,
@@ -141,6 +147,7 @@ class AnalyticsService:
         additional_metadata: Optional[Dict[str, Any]] = None
     ):
         """Log an invalid attempt."""
+        session = None
         try:
             session = get_session()
             invalid_record = InvalidAttempt(
@@ -174,13 +181,16 @@ class AnalyticsService:
                 "reason": reason,
                 "error": str(e)
             })
-            session.rollback()
+            if session:
+                session.rollback()
             raise
         finally:
-            session.close()
+            if session:
+                session.close()
     
     def get_stats_for_event(self, event_id: str) -> Dict[str, int]:
         """Get analytics stats for a specific event."""
+        session = None
         try:
             session = get_session()
             
@@ -252,10 +262,12 @@ class AnalyticsService:
             })
             raise
         finally:
-            session.close()
+            if session:
+                session.close()
     
     def get_stats_for_all_events(self) -> Dict[str, Dict[str, int]]:
         """Get analytics stats for all events."""
+        session = None
         try:
             session = get_session()
             
@@ -277,10 +289,12 @@ class AnalyticsService:
             log_error("Failed to get stats for all events", {"error": str(e)})
             raise
         finally:
-            session.close()
+            if session:
+                session.close()
     
     def get_recent_scans(self, event_id: str, from_ts: Optional[datetime] = None, to_ts: Optional[datetime] = None, page: int = 1, limit: int = 100) -> Dict[str, Any]:
         """Get recent scan records for an event with date filtering and pagination."""
+        session = None
         try:
             session = get_session()
             
@@ -323,10 +337,12 @@ class AnalyticsService:
             })
             raise
         finally:
-            session.close()
+            if session:
+                session.close()
 
     def get_scans_by_ticket_id(self, ticket_id: str, limit: int = 100) -> List[Dict[str, Any]]:
         """Get scan records for a specific ticket identifier."""
+        session = None
         try:
             session = get_session()
             scans = session.query(TicketScan).filter(
@@ -347,10 +363,12 @@ class AnalyticsService:
             })
             raise
         finally:
-            session.close()
+            if session:
+                session.close()
     
     def get_recent_transfers(self, event_id: str, from_ts: Optional[datetime] = None, to_ts: Optional[datetime] = None, page: int = 1, limit: int = 100) -> Dict[str, Any]:
         """Get recent transfer records for an event with date filtering and pagination."""
+        session = None
         try:
             session = get_session()
             
@@ -394,10 +412,12 @@ class AnalyticsService:
             })
             raise
         finally:
-            session.close()
+            if session:
+                session.close()
     
     def get_invalid_attempts(self, event_id: str, from_ts: Optional[datetime] = None, to_ts: Optional[datetime] = None, page: int = 1, limit: int = 100) -> Dict[str, Any]:
         """Get recent invalid attempt records for an event with date filtering and pagination."""
+        session = None
         try:
             session = get_session()
             
@@ -440,7 +460,8 @@ class AnalyticsService:
             })
             raise
         finally:
-            session.close()
+            if session:
+                session.close()
     
     def get_trending_events(self, limit: int = 10, hours: int = 24) -> List[Dict[str, Any]]:
         """Return top events by scan velocity over the last N hours.


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is this change needed? -->
 resolve the unbound session variable in AnalyticsService exception handlers
Every method in src/analytics/service.py catches a broad Exception and then calls session.rollback() inside the except block. If the exception is raised before session = get_session() is called (e.g. on import or argument error), session is unbound and the handler itself raises a NameError, masking the original error and crashing the request.

Root cause
def log_ticket_scan(self, ...):
    try:
        session = get_session()   # ← if this raises, session is unbound
        ...
    except Exception as e:
        session.rollback()        # ← NameError here hides the real error
Requirements & context
Wrap every session = get_session() call so that session is always defined before it can be referenced in except/finally
The canonical fix is to move session initialisation before the try block and use a finally clause for cleanup, or use a context manager
Apply the fix consistently across all six methods: log_ticket_scan, log_ticket_transfer, log_invalid_attempt, get_stats_for_event, get_stats_for_all_events, get_recent_scans, get_recent_transfers, get_invalid_attempts, _update_analytics_stats
Add a unit test that mocks get_session() to raise and confirms the original exception propagates without a secondary NameError

Closes #119

---
 fixed resolve unbound session variable in AnalyticsService exception handlers

Description
Every method in src/analytics/service.py catches a broad Exception and then calls session.rollback() inside the except block. If the exception is raised before session = get_session() is called (e.g. on import or argument error), session is unbound and the handler itself raises a NameError, masking the original error and crashing the request.

Root cause
def log_ticket_scan(self, ...):
    try:
        session = get_session()   # ← if this raises, session is unbound
        ...
    except Exception as e:
        session.rollback()        # ← NameError here hides the real error
Requirements & context
Wrap every session = get_session() call so that session is always defined before it can be referenced in except/finally
The canonical fix is to move session initialisation before the try block and use a finally clause for cleanup, or use a context manager
Apply the fix consistently across all six methods: log_ticket_scan, log_ticket_transfer, log_invalid_attempt, get_stats_for_event, get_stats_for_all_events, get_recent_scans, get_recent_transfers, get_invalid_attempts, _update_analytics_stats
Add a unit test that mocks get_session() to raise and confirms the original exception propagates without a secondary NameError
Suggested execution
git checkout -b fix/analytics-session-unbound
Refactor each method to use session = None before try, assign inside, and guard session.rollback() with if session:
Or use SQLAlchemy session as a context manager: with Session(engine) as session:
Add/update tests in tests/

closes #118 