### PR TITLE
fix: resolve issues #120, #121, #122, #123 (Stellar Wave)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,10 @@
 # Required in all environments. Must be at least 32 characters.
 QR_SIGNING_KEY=replace_with_a_minimum_32_character_secret_key
+
+# API keys — required, no defaults. Must be at least 32 characters.
+# Never use the placeholder values below in production.
+# SERVICE_API_KEY=<generate_a_secure_random_32plus_char_secret>
+# ADMIN_API_KEY=<generate_a_secure_random_32plus_char_secret>
 DATABASE_URL=postgresql://veritix:veritix@localhost:5432/veritix
 NEST_API_BASE_URL=https://api.example.com
 NEST_API_TOKEN=your_nest_api_token

--- a/src/analytics/service.py
+++ b/src/analytics/service.py
@@ -599,6 +599,7 @@ class AnalyticsService:
                                increment_transfer: bool = False, is_successful: bool = True,
                                increment_invalid: bool = False):
         """Internal method to update analytics stats."""
+        session = None
         try:
             session = get_session()
             
@@ -645,9 +646,11 @@ class AnalyticsService:
                 "event_id": event_id,
                 "error": str(e)
             })
-            session.rollback()
+            if session:
+                session.rollback()
         finally:
-            session.close()
+            if session:
+                session.close()
 
 
 # Global instance

--- a/src/auth/dependencies.py
+++ b/src/auth/dependencies.py
@@ -3,7 +3,7 @@ import secrets
 from fastapi import Depends, HTTPException, status
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 
-from src.config import settings
+from src.config import get_settings
 
 # auto_error=False allows us to manually raise 401 when header is absent.
 bearer_scheme = HTTPBearer(auto_error=False)
@@ -19,7 +19,7 @@ def require_service_key(
             detail="Missing or invalid authentication token",
         )
 
-    if not secrets.compare_digest(credentials.credentials, settings.SERVICE_API_KEY):
+    if not secrets.compare_digest(credentials.credentials, get_settings().SERVICE_API_KEY):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Invalid service token",
@@ -38,7 +38,7 @@ def require_admin_key(
             detail="Missing or invalid authentication token",
         )
 
-    if not secrets.compare_digest(credentials.credentials, settings.ADMIN_API_KEY):
+    if not secrets.compare_digest(credentials.credentials, get_settings().ADMIN_API_KEY):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Invalid admin token",

--- a/src/config.py
+++ b/src/config.py
@@ -1,7 +1,7 @@
 from functools import lru_cache
 from typing import Optional
 
-from pydantic import Field
+from pydantic import Field, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 class Settings(BaseSettings):
@@ -35,15 +35,22 @@ class Settings(BaseSettings):
     REPORT_CACHE_MINUTES: int = 60
     SHUTDOWN_TIMEOUT_SECONDS: int = 30
 
-    SERVICE_API_KEY: str = "default_service_secret_change_me"
-    ADMIN_API_KEY: str = "default_admin_secret_change_me"
+    SERVICE_API_KEY: str = Field(...)
+    ADMIN_API_KEY: str = Field(...)
+
+    @field_validator("SERVICE_API_KEY", "ADMIN_API_KEY")
+    @classmethod
+    def validate_api_keys(cls, v: str, info) -> str:
+        forbidden = {"default_service_secret_change_me", "default_admin_secret_change_me"}
+        if v in forbidden or len(v) < 32:
+            raise ValueError(
+                f"{info.field_name} must be at least 32 characters and must not use a default value"
+            )
+        return v
     KNOWN_LOCATIONS: str = (
         "lagos,abuja,port harcourt,kano,ibadan,benin,kaduna,jos,enugu,calabar,"
         "owerri,warri,uyo,akure,ilorin,sokoto,zaria,maiduguri,asaba,nnewi"
     )
-
-settings = Settings()
-
 
 @lru_cache
 def get_settings() -> Settings:

--- a/src/report_service.py
+++ b/src/report_service.py
@@ -276,19 +276,39 @@ def _query_event_names() -> Dict[str, str]:
 
 
 def _query_transfer_stats(target_date: Optional[date] = None) -> Dict[str, int]:
-    """Query transfer statistics.
+    engine = _pg_engine()
+    if engine is None:
+        logger.warning("DATABASE_URL not set; cannot query transfer stats")
+        return {"total_transfers": 0}
 
-    Returns a placeholder dict; a real implementation would query a transfers table.
-    """
-    return {"total_transfers": 0}
+    if target_date is None:
+        target_date = date.today()
+
+    with engine.connect() as conn:
+        result = conn.execute(
+            text("SELECT COUNT(*) FROM ticket_transfers WHERE transfer_timestamp::date = :target_date"),
+            {"target_date": target_date},
+        )
+        row = result.fetchone()
+    return {"total_transfers": int(row[0]) if row else 0}
 
 
 def _query_invalid_scans(target_date: Optional[date] = None) -> Dict[str, int]:
-    """Query invalid scan statistics.
+    engine = _pg_engine()
+    if engine is None:
+        logger.warning("DATABASE_URL not set; cannot query invalid scan stats")
+        return {"invalid_scans": 0}
 
-    Returns a placeholder dict; a real implementation would query a scans table.
-    """
-    return {"invalid_scans": 0}
+    if target_date is None:
+        target_date = date.today()
+
+    with engine.connect() as conn:
+        result = conn.execute(
+            text("SELECT COUNT(*) FROM invalid_attempts WHERE attempt_timestamp::date = :target_date"),
+            {"target_date": target_date},
+        )
+        row = result.fetchone()
+    return {"invalid_scans": int(row[0]) if row else 0}
 
 
 def generate_daily_report_csv(

--- a/src/tests/test_auth.py
+++ b/src/tests/test_auth.py
@@ -2,7 +2,7 @@ import pytest
 from fastapi import FastAPI, Depends
 from fastapi.testclient import TestClient
 from src.auth.dependencies import require_service_key, require_admin_key
-from src.config import settings
+from src.config import get_settings
 
 # Setup a dummy FastAPI app for isolated auth testing
 app = FastAPI()
@@ -41,21 +41,21 @@ def test_invalid_token():
     assert response.json()["detail"] == "Invalid admin token"
 
 def test_valid_service_token():
-    headers = {"Authorization": f"Bearer {settings.SERVICE_API_KEY}"}
+    headers = {"Authorization": f"Bearer {get_settings().SERVICE_API_KEY}"}
     response = client.get("/service-protected", headers=headers)
     assert response.status_code == 200
     assert response.json()["msg"] == "service success"
 
 def test_valid_admin_token():
-    headers = {"Authorization": f"Bearer {settings.ADMIN_API_KEY}"}
+    headers = {"Authorization": f"Bearer {get_settings().ADMIN_API_KEY}"}
     response = client.get("/admin-protected", headers=headers)
     assert response.status_code == 200
     assert response.json()["msg"] == "admin success"
 
 def test_cross_auth_fails():
     """Ensure a valid service token cannot access an admin route and vice-versa."""
-    service_headers = {"Authorization": f"Bearer {settings.SERVICE_API_KEY}"}
-    admin_headers = {"Authorization": f"Bearer {settings.ADMIN_API_KEY}"}
+    service_headers = {"Authorization": f"Bearer {get_settings().SERVICE_API_KEY}"}
+    admin_headers = {"Authorization": f"Bearer {get_settings().ADMIN_API_KEY}"}
     
     response1 = client.get("/admin-protected", headers=service_headers)
     assert response1.status_code == 403

--- a/tests/test_heatmap.py
+++ b/tests/test_heatmap.py
@@ -6,12 +6,12 @@ import pytest
 from fastapi.testclient import TestClient
 
 from src.analytics.service import AnalyticsService
-from src.config import settings
+from src.config import get_settings
 from src.main import app
 
 client = TestClient(app)
 
-SERVICE_HEADERS = {"Authorization": f"Bearer {settings.SERVICE_API_KEY}"}
+SERVICE_HEADERS = {"Authorization": f"Bearer {get_settings().SERVICE_API_KEY}"}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_reports_list.py
+++ b/tests/test_reports_list.py
@@ -10,13 +10,13 @@ from unittest.mock import MagicMock, patch
 import pytest
 from fastapi.testclient import TestClient
 
-from src.config import settings
+from src.config import get_settings
 from src.main import app
 from src.report_service import REPORTS_DIR
 
 client = TestClient(app)
 
-ADMIN_HEADERS = {"Authorization": f"Bearer {settings.ADMIN_API_KEY}"}
+ADMIN_HEADERS = {"Authorization": f"Bearer {get_settings().ADMIN_API_KEY}"}
 
 # ---------------------------------------------------------------------------
 # Helpers / fixtures


### PR DESCRIPTION
- #121: remove module-level Settings() instantiation; all callers now use get_settings()
- #122: make SERVICE_API_KEY and ADMIN_API_KEY required with field_validator enforcing min 32 chars and rejecting known defaults; update .env.example
- #123: implement _query_transfer_stats and _query_invalid_scans with real DB queries against ticket_transfers and invalid_attempts tables
- #120: initialise session=None before try block in _update_analytics_stats and guard rollback/close with `if session:`

Closes #120
Closes #121
Closes #122
Closes #123


## Checklist

- [ ] This PR closes an open issue (linked above)
- [ ] Tests added or updated for all changed behaviour
- [ ] Coverage is maintained or improved
- [ ] Docs updated if endpoints or config options changed (`docs/api-reference.md`, `docs/etl-pipeline.md`)
- [ ] `black`, `isort`, and `mypy` pass locally
- [ ] CI is green
